### PR TITLE
Support Init without WSDL

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ SOAP is old, but still used. Soapy is modern, but feature limited to fit our use
 Heavily inspired by [artisaninweb/laravel-soap](https://github.com/artisaninweb/laravel-soap).
 
 ### Install
-This package is currently supporting Laravel 6.x.
+This package is currently supporting Laravel 7.x.
 
 ```
 composer require sourcetoad/soapy
@@ -20,6 +20,7 @@ This package will use Laravel Auto Discovery to automatically register the Servi
  * **trace** - Whether to expose internal methods on SoapClient.
  * **cache** - Flag to use for WSDL cache.
  * **location** - Override URL to use for SOAP Requests.
+ * **uri** - Overide namespace to use for SOAP Requests.
  * **certificate** - Certificate path for authentication with Server.
  * **options** - Array of any settings from [SoapClient#options](https://www.php.net/manual/en/soapclient.soapclient.php#options)
  * **classmap** - Array of class maps to map objects -> classes.

--- a/src/Exceptions/CurtainRequiresWsdlException.php
+++ b/src/Exceptions/CurtainRequiresWsdlException.php
@@ -5,5 +5,5 @@ namespace Sourcetoad\Soapy\Exceptions;
 
 class CurtainRequiresWsdlException extends \Exception
 {
-    protected $message = 'Curtain requires calling getWsdl() in order to populate class.';
+    protected $message = 'Curtain requires calling setWsdl() or setLocation/setUri in order to populate class.';
 }

--- a/src/SoapyCurtain.php
+++ b/src/SoapyCurtain.php
@@ -5,8 +5,8 @@ namespace Sourcetoad\Soapy;
 
 class SoapyCurtain
 {
-    /** @var string */
-    protected $wsdl = '';
+    /** @var string|null */
+    protected $wsdl = null;
 
     /** @var bool */
     protected $trace = false;
@@ -15,10 +15,10 @@ class SoapyCurtain
     protected $cache = WSDL_CACHE_NONE;
 
     /** @var string|null */
-    protected $location;
+    protected $location = null;
 
     /** @var string|null */
-    protected $uri;
+    protected $uri = null;
 
     /** @var string */
     protected $certificate;

--- a/src/SoapyCurtain.php
+++ b/src/SoapyCurtain.php
@@ -14,8 +14,11 @@ class SoapyCurtain
     /** @var int */
     protected $cache = WSDL_CACHE_NONE;
 
-    /** @var string */
+    /** @var string|null */
     protected $location;
+
+    /** @var string|null */
+    protected $uri;
 
     /** @var string */
     protected $certificate;
@@ -31,7 +34,7 @@ class SoapyCurtain
 
     #region getters
 
-    public function getWsdl(): string
+    public function getWsdl(): ?string
     {
         return $this->wsdl;
     }
@@ -56,6 +59,11 @@ class SoapyCurtain
         return $this->location;
     }
 
+    public function getUri(): ?string
+    {
+        return $this->uri;
+    }
+
     public function getOptions(): array
     {
         $baseOptions = [
@@ -77,6 +85,10 @@ class SoapyCurtain
 
         if ($this->getLocation()) {
             $baseOptions['location'] = $this->getLocation();
+        }
+
+        if ($this->getUri()) {
+            $baseOptions['uri'] = $this->getUri();
         }
 
         return array_merge($this->options, $baseOptions);
@@ -152,6 +164,12 @@ class SoapyCurtain
         return $this;
     }
 
+    public function setUri(string $uri): self
+    {
+        $this->uri = $uri;
+        return $this;
+    }
+
     public function addTypeMapViaClassName(string $namespace, string $item, string $itemClass)
     {
         $function = function (string $xml) use ($itemClass) {
@@ -172,6 +190,19 @@ class SoapyCurtain
 
         $this->typeMap[] = $typeMap;
         return $this;
+    }
+
+    #endregion
+
+    #region functions
+
+    public function isReady(): bool
+    {
+        if (! empty($this->getLocation()) && ! empty($this->getUri())) {
+            return true;
+        }
+
+        return !empty($this->getWsdl());
     }
 
     #endregion

--- a/src/SoapyTub.php
+++ b/src/SoapyTub.php
@@ -29,7 +29,7 @@ class SoapyTub
             $soapyClient = $soapClient;
         }
 
-        if (empty($service->getWsdl())) {
+        if (! $service->isReady()) {
             throw new CurtainRequiresWsdlException();
         }
 


### PR DESCRIPTION
Noticed with a few projects that PHP (why) reaches out to services in a WSDL file. So if you have a service that is down and taking 3+ minutes to respond. Your service can die. Soapy never supported a non-wsdl onboarding experience. This is the build out for that.