### PR TITLE
Add PHP 8.5 to supported versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [8.2, 8.3, 8.4]
+        php: [8.2, 8.3, 8.4, 8.5]
         laravel: [11.0, 12.0]
     name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }}
     steps:

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         }
     ],
     "require": {
-        "php": "^8.2||^8.3||^8.4",
+        "php": "^8.2||^8.3||^8.4||^8.5",
         "ext-simplexml": "*",
         "ext-soap": "*",
         "illuminate/support": "^11.0|^12.0"


### PR DESCRIPTION
Adds PHP 8.5 to the supported versions and CI matrix. There is a deprecation warning in the PHP 8.5 + Laravel 11 tests due to testbench's config using a constant that is deprecated on 8.5.