### PR TITLE
chore: drop Laravel 11 support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: true
       matrix:
         php: [8.2, 8.3, 8.4, 8.5]
-        laravel: [11.0, 12.0, 13.0]
+        laravel: [12.0, 13.0]
         exclude:
           - php: 8.2
             laravel: 13.0

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ SOAP is old, but still used. Soapy is modern, but feature limited to fit our use
 Heavily inspired by [artisaninweb/laravel-soap](https://github.com/artisaninweb/laravel-soap).
 
 ### Install
-This package is currently supporting Laravel 11.x and 12.x.
+This package is currently supporting Laravel 12.x & 13.x
 
 ```shell
 composer require sourcetoad/soapy

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "php": "^8.2||^8.3||^8.4||^8.5",
         "ext-simplexml": "*",
         "ext-soap": "*",
-        "illuminate/support": "^11.0|^12.0|^13.0"
+        "illuminate/support": "^12.0|^13.0"
     },
     "require-dev": {
         "orchestra/testbench": "^9.2|^10.0|^11.0",


### PR DESCRIPTION
Laravel 11 is EOL now - https://endoflife.date/laravel